### PR TITLE
Allow selection between pyzmq and pyzmq-static.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,13 @@ except ImportError:
     from distutils.core import setup
 
 
+import os
+if os.environ.get('STATIC_DEPS', None) in ('1', 'true'):
+    PYZMQ_PACKAGE = 'pyzmq-static>=2.1.7,<2.2'
+else:
+    PYZMQ_PACKAGE = 'pyzmq>=2.1.11,<2.2'
+
+
 setup(
     name='zerorpc',
     version=zerorpc.__version__,
@@ -41,7 +48,7 @@ setup(
             'argparse',
             'gevent',
             'msgpack-python',
-            'pyzmq-static==2.1.7',
+            PYZMQ_PACKAGE,
     ],
     zip_safe=False,
     scripts=[


### PR DESCRIPTION
STATIC_DEPS=1 on the command line will turn on pyzmq-static dependency; otherwise, pyzmq itself is used.

I added this because it was easy to install a pre-built binary egg for pyzmq on Windows, but could not easily install pyzmq-static.

Note that I have not yet tested this.  I'll have another, separate patch soon that makes the "zerorpc-client" script install correctly on Windows.
