### PR TITLE
Add a tox.ini for tox (http://tox.testrun.org/) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 dist/
 *.egg
 *.egg-info
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py26,py27,py31,py32
+
+[testenv]
+deps=nose
+commands=nosetests


### PR DESCRIPTION
to make it easier to test in clean environments and across multiple versions of python.
