### PR TITLE
Update pyzeromq-static version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
             'argparse',
             'gevent',
             'msgpack-python',
-            'pyzmq-static>=2.1.7',
+            'pyzmq-static',
     ],
     zip_safe=False,
     scripts=[


### PR DESCRIPTION
The version required for pyzmq-static (2.1.7) is no longer the "official" version - it is now 2.1.7.1, and forks that have been updated to 2.1.11 are available. Accordingly, this doesn't install using the straightforward pip install method. This just changes the setup.py to make the version requirement >=2.1.7, so that the default build will still work, but the 2.1.11 build will also work.
