### PR TITLE
Setup.py tweaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,10 @@ setup(
             'argparse',
             'gevent',
             'msgpack-python==0.1.12',
-            'pyzmq-static==2.1.7',
+            'pyzmq-static>=2.1.7',
     ],
+    tests_require=['nose'],
+    test_suite='nose.collector',
     zip_safe=False,
     scripts=[
             'bin/zerorpc'


### PR DESCRIPTION
1. update `pyzmq-static` dependency (to `pyzmq-static>=2.1.7` since [2.1.7.1 is on PyPI](http://pypi.python.org/pypi/pyzmq-static/2.1.7.1))
2. add `tests_require` and `test_suite` arguments so that `python setup.py test` works
3. Pin `msgpack-python` dependency to [`msgpack-python==0.1.12`](http://pypi.python.org/pypi/msgpack-python/0.1.12) since one of the tests (`tests.test_reqstream.test_rcp_streaming`) fails for me (`TypeError: can't serialize xrange(10)`) with [msgpack-python==0.1.13](http://pypi.python.org/pypi/msgpack-python/0.1.13).
