### PR TITLE
Add an “inspect_error” middleware hook

### DIFF
--- a/zerorpc/context.py
+++ b/zerorpc/context.py
@@ -35,12 +35,13 @@ class Context(zmq.Context):
     def __init__(self):
         self._middlewares = []
         self._middlewares_hooks = {
-                'resolve_endpoint': [],
-                'raise_error': [],
-                'call_procedure': [],
-                'load_task_context': [],
-                'get_task_context': [],
-                }
+            'resolve_endpoint': [],
+            'raise_error': [],
+            'call_procedure': [],
+            'load_task_context': [],
+            'get_task_context': [],
+            'inspect_error': []
+        }
 
     @staticmethod
     def get_instance():
@@ -70,6 +71,12 @@ class Context(zmq.Context):
         for functor in self._middlewares_hooks['resolve_endpoint']:
             endpoint = functor(endpoint)
         return endpoint
+
+    def middleware_inspect_error(self, exc_type, exc_value, exc_traceback):
+        exc_info = exc_type, exc_value, exc_traceback
+        task_context = self.middleware_get_task_context()
+        for functor in self._middlewares_hooks['inspect_error']:
+            functor(task_context, exc_info)
 
     def middleware_raise_error(self, event):
         for functor in self._middlewares_hooks['raise_error']:

--- a/zerorpc/core.py
+++ b/zerorpc/core.py
@@ -113,6 +113,9 @@ class ServerBase(object):
             traceback.print_exception(exc_type, exc_value, exc_traceback,
                     file=sys.stderr)
 
+            self._context.middleware_inspect_error(exc_type, exc_value,
+                    exc_traceback)
+
             if protocol_v1:
                 return (repr(exc_value),)
 


### PR DESCRIPTION
This middleware will be called when an exception is raised server side.

It receives the context of the call and the exception informations in
parameters. For example, this can be used to integrate Sentry and
ZeroRPC.
