### PR TITLE
Call the inspect_error middleware hook in Puller

### DIFF
--- a/zerorpc/core.py
+++ b/zerorpc/core.py
@@ -320,7 +320,14 @@ class Puller(SocketBase):
                     self._methods[event.name],
                     *event.args)
             except Exception:
-                traceback.print_exc(file=sys.stderr)
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                try:
+                    traceback.print_exception(exc_type, exc_value, exc_traceback,
+                            file=sys.stderr)
+                    self._context.middleware_inspect_error(exc_type, exc_value,
+                            exc_traceback)
+                finally:
+                    del exc_traceback
 
     def run(self):
         self._receiver_task = gevent.spawn(self._receiver)


### PR DESCRIPTION
Puller is unrelated with ServerBase (the REQ/REP base server-side class)
and the call to the inspect_error middleware hook introduced in 0.2.0
was just missing.

A new unit test has been added too, we should probably bump the patch version!
