### PR TITLE
'NoneType' object is not subscriptable

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -204,7 +204,6 @@ def test_exception_compat_v1():
 
 
 def test_removed_unscriptable_error_format_args_spec():
-
     class MySrv(zerorpc.Server):
         pass
 


### PR DESCRIPTION
Pull request is for change in 5169ce62f4edc614a9a9b0da61f68c2c187d9bf2.  

When running the example `zerorpc --server --bind tcp://*:1234 time``then connecting with a client the following error is encountered:``TypeError: 'NoneType' object is not subscriptable``.   
