### PR TITLE
Add argparse as install requirement only when Python < 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,12 @@ except ImportError:
 
 
 requirements = [
-        'gevent',
-        'msgpack-python',
-        'pyzmq>=2.2.0.1'
+    'gevent',
+    'msgpack-python',
+    'pyzmq>=2.2.0.1'
 ]
 if sys.version_info < (2, 7):
-        requirements.append('argparse')
+    requirements.append('argparse')
 
 
 setup(


### PR DESCRIPTION
Tested with clean virtualenvs with Python 2.6 and 2.7 on OS X 10.8.2. Argparse gets installed in the 2.6 but not in 2.7, as intended.
