### PR TITLE
Moving zerorpc to a console_script entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,7 @@ setup(
     tests_require=['nose'],
     test_suite='nose.collector',
     zip_safe=False,
-    scripts=[
-            'bin/zerorpc'
-        ],
+    entry_points={'console_scripts': ['zerorpc = zerorpc.cli:main']},
     license='MIT',
     classifiers=(
         'Development Status :: 5 - Production/Stable',

--- a/zerorpc/cli.py
+++ b/zerorpc/cli.py
@@ -270,5 +270,3 @@ def main():
 
     return run_server(args)
 
-if __name__ == '__main__':
-    exit(main())


### PR DESCRIPTION
When using 'scripts', the scripts are installed as-is, which is a problem with:
- easy_install-in on Windows -- no executable wrapper is created
- buildout environments -- no wrapper is created

When using console_scripts entry points, all of these are created just fine.
The switch is simple and easy and does not break anything, but it does moving the 'zerorpc' script inside the package
