### PR TITLE
Pinning pyzmq requirement to 2.2.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ except ImportError:
 requirements = [
     'gevent',
     'msgpack-python',
-    'pyzmq>=2.2.0.1'
+    'pyzmq==2.2.0.1'
 ]
 if sys.version_info < (2, 7):
     requirements.append('argparse')


### PR DESCRIPTION
Pinning pyzmq requirement to 2.2.0.1, instead of saying anything above 2.2.0.1 is good, because it is breaking due to pyzmq 13.0
We should pin to 2.2.0.1 until we know it works fine on a higher version.
