### PR TITLE
the latest zerorpc code needs at least pyzmq 13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ except ImportError:
 requirements = [
     'gevent',
     'msgpack-python',
-    'pyzmq>=2.2.0.1'
+    'pyzmq>=13'
 ]
 if sys.version_info < (2, 7):
     requirements.append('argparse')


### PR DESCRIPTION
zerorpc 0.4.3 is incompatible with pyzmq 2.2.0.1.

How to reproduce:

```
mkvirtualenv tmp
pip install pyzmq==2.2.0.1
pip install zerorpc
zerorpc --server urllib --bind tcp://0.0.0.0:1234
...
KeyError: '_msg_id_counter'
```

Upgrading to pyzmq 13.0 (or later) fixes the problem.

I think it's useful to upgrade the dependencies correctly, because people trying to upgrade zerorpc will break their existing install (since the current deps only specify pyzmq>=2.2.0.1).
