### PR TITLE
use logging instead of printing to stderr

### DIFF
--- a/zerorpc/channel.py
+++ b/zerorpc/channel.py
@@ -32,6 +32,11 @@ import gevent.coros
 
 from .exceptions import TimeoutExpired
 
+from logging import getLogger
+
+logger = getLogger(__name__)
+
+
 
 class ChannelMultiplexer(object):
     def __init__(self, events, ignore_broadcast=False):
@@ -76,9 +81,9 @@ class ChannelMultiplexer(object):
             try:
                 event = self._events.recv()
             except Exception as e:
-                print >> sys.stderr, \
-                        'zerorpc.ChannelMultiplexer,', \
-                        'ignoring error on recv: {0}'.format(e)
+                logger.error( \
+                        'zerorpc.ChannelMultiplexer, ' + \
+                        'ignoring error on recv: {0}'.format(e))
                 continue
             channel_id = event.header.get('response_to', None)
 
@@ -91,10 +96,10 @@ class ChannelMultiplexer(object):
                 queue = self._broadcast_queue
 
             if queue is None:
-                print >> sys.stderr, \
-                        'zerorpc.ChannelMultiplexer,', \
-                        'unable to route event:', \
-                        event.__str__(ignore_args=True)
+                logger.error( \
+                        'zerorpc.ChannelMultiplexer, ' + \
+                        'unable to route event: ' + \
+                        event.__str__(ignore_args=True))
             else:
                 queue.put(event)
 
@@ -210,9 +215,9 @@ class BufferedChannel(object):
                 try:
                     self._remote_queue_open_slots += int(event.args[0])
                 except Exception as e:
-                    print >> sys.stderr, \
-                            'gevent_zerorpc.BufferedChannel._recver,', \
-                            'exception:', e
+                    logger.error( \
+                            'gevent_zerorpc.BufferedChannel._recver, ' + \
+                            'exception: ' + repr(e))
                 if self._remote_queue_open_slots > 0:
                     self._remote_can_recv.set()
             elif self._input_queue.qsize() == self._input_queue_size:

--- a/zerorpc/core.py
+++ b/zerorpc/core.py
@@ -39,6 +39,10 @@ from .heartbeat import HeartBeatOnChannel
 from .context import Context
 from .decorators import DecoratorBase, rep
 import patterns
+from logging import getLogger
+
+logger = getLogger(__name__)
+
 
 class ServerBase(object):
 
@@ -118,7 +122,7 @@ class ServerBase(object):
         return self._methods[method](*args)
 
     def _print_traceback(self, protocol_v1, exc_infos):
-        traceback.print_exception(*exc_infos, file=sys.stderr)
+        logger.exception('')
 
         exc_type, exc_value, exc_traceback = exc_infos
         if protocol_v1:
@@ -337,7 +341,7 @@ class Puller(SocketBase):
             except Exception:
                 exc_infos = sys.exc_info()
                 try:
-                    traceback.print_exception(*exc_infos, file=sys.stderr)
+                    logger.exception('')
                     self._context.hook_server_inspect_exception(event, None, exc_infos)
                 finally:
                     del exc_infos

--- a/zerorpc/gevent_zmq.py
+++ b/zerorpc/gevent_zmq.py
@@ -34,6 +34,9 @@ import gevent.event
 import gevent.core
 import sys
 import errno
+from logging import getLogger
+
+logger = getLogger(__name__)
 
 class Context(_zmq.Context):
 
@@ -125,8 +128,8 @@ class Socket(_zmq.Socket):
             gevent.sleep(0)
             while not self._writable.wait(timeout=1):
                 if self.getsockopt(_zmq.EVENTS) & _zmq.POLLOUT:
-                    print>>sys.stderr, "/!\\ gevent_zeromq BUG /!\\ " \
-                        "catching up after missing event (SEND) /!\\"
+                    logger.error("/!\\ gevent_zeromq BUG /!\\ " + \
+                        "catching up after missing event (SEND) /!\\")
                     break
 
     def recv(self, flags=0, copy=True, track=False):
@@ -161,6 +164,6 @@ class Socket(_zmq.Socket):
             gevent.sleep(0)
             while not self._readable.wait(timeout=1):
                 if self.getsockopt(_zmq.EVENTS) & _zmq.POLLIN:
-                    print>>sys.stderr, "/!\\ gevent_zeromq BUG /!\\ " \
-                        "catching up after missing event (RECV) /!\\"
+                    logger.error("/!\\ gevent_zeromq BUG /!\\ " + \
+                        "catching up after missing event (RECV) /!\\")
                     break


### PR DESCRIPTION
printing to stderr makes test output harder to read. using the logging module instead fixes this and also allows the developer to control if and when the zerorpc errors are printed.
