### PR TITLE
Additional fixes for Issue #41

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,11 +186,11 @@ Let's save this code to *cooler.py* and run it::
 
 Now, in another terminal, let's try connecting to our awesome zeroservice::
 
-  $ zerorpc -j tcp://:4242 add_42 1
+  $ zerorpc -j tcp://localhost:4242 add_42 1
   43
-  $ zerorpc tcp://:4242 add_man 'I own a mint-condition Volkswagen Golf'
+  $ zerorpc tcp://localhost:4242 add_man 'I own a mint-condition Volkswagen Golf'
   "I own a mint-condition Volkswagen Golf, man!"
-  $ zerorpc tcp://:4242 boat 'I own a mint-condition Volkswagen Golf, man!'
+  $ zerorpc tcp://localhost:4242 boat 'I own a mint-condition Volkswagen Golf, man!'
   "I'm on a boat!"
 
 


### PR DESCRIPTION
Issue #41 was about an `zmq.core.error.ZMQError: Invalid argument` error when trying to connect to `tcp://*:4242`, however I ran into the same bug in Ubuntu 13.04 connecting to `tcp://:4242`.
