### PR TITLE
Using mirrors is no longer recommended by pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install python-dev libevent-dev
 install:
-  - pip install nose --use-mirrors
-  - pip install . --use-mirrors
+  - pip install nose
+  - pip install .


### PR DESCRIPTION
PyPi now serves packages using a CDN.
