### PR TITLE
Replace execfile with something that works under both Python 2 and 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-execfile('zerorpc/version.py')
+# execfile() doesn't exist in Python 3, this way we are compatible with both.
+exec(compile(open('zerorpc/version.py').read(), 'zerorpc/version.py', 'exec'))
+
 import sys
 
 


### PR DESCRIPTION
Execfile doesn't exist in Python 3, this commit replaces the use of
execfile with an equivalent construct known to work under both versions
of Python.

The change is actually the result of running 2to3 over setup.py, I just
added a note to explain its presence.
