### PR TITLE
Initialize methods in context.py and added __init__.py

### DIFF
--- a/zerorpc/context.py
+++ b/zerorpc/context.py
@@ -34,8 +34,8 @@ class Context(zmq.Context):
 
     def __init__(self):
         super(zmq.Context, self).__init__()
-        self._middlewares = []
-        self._hooks = {
+        self.__dict__['_middlewares'] = []
+        self.__dict__['_hooks'] = {
             'resolve_endpoint': [],
             'load_task_context': [],
             'get_task_context': [],
@@ -46,6 +46,9 @@ class Context(zmq.Context):
             'client_before_request': [],
             'client_after_request': []
         }
+        prop_funcs = ['_middlewares','_msg_id_base', '_msg_id_counter', '_msg_id_counter_stop']
+        for func in prop_funcs:
+            self.__dict__[func] = 0
         self._reset_msgid()
 
     # NOTE: pyzmq 13.0.0 messed up with setattr (they turned it into a

--- a/zerorpc/context.py
+++ b/zerorpc/context.py
@@ -46,7 +46,7 @@ class Context(zmq.Context):
             'client_before_request': [],
             'client_after_request': []
         }
-        prop_funcs = ['_middlewares','_msg_id_base', '_msg_id_counter', '_msg_id_counter_stop']
+        prop_funcs = ['_msg_id_base', '_msg_id_counter', '_msg_id_counter_stop']
         for func in prop_funcs:
             self.__dict__[func] = 0
         self._reset_msgid()


### PR DESCRIPTION
Zerorpc-python doesn't even run without initializing the following methods in context.py:

_msg_id_base, _msg_id_counter, _msg_id_counter_stop

Major bug fix, init @properties in context.py
Added init to make a py module