### PR TITLE
Faster unit tests!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - env: PYZMQ='pyzmq==14.1.1'
 script: 
   - flake8 --ignore=E501,E128 zerorpc bin
-  - nosetests
+  - ZPC_TEST_TIME_FACTOR=0.1 nosetests
 before_install:
   - sudo apt-get update
   - sudo apt-get install python-dev libevent-dev

--- a/tests/test_buffered_channel.py
+++ b/tests/test_buffered_channel.py
@@ -29,7 +29,7 @@ import sys
 
 from zerorpc import zmq
 import zerorpc
-from testutils import teardown, random_ipc_endpoint
+from testutils import teardown, random_ipc_endpoint, TIME_FACTOR
 
 
 def test_close_server_bufchan():
@@ -43,17 +43,17 @@ def test_close_server_bufchan():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
     client_bufchan = zerorpc.BufferedChannel(client_hbchan)
     client_bufchan.emit('openthat', None)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
     server_bufchan = zerorpc.BufferedChannel(server_hbchan)
     server_bufchan.recv()
 
-    gevent.sleep(3)
+    gevent.sleep(TIME_FACTOR * 3)
     print 'CLOSE SERVER SOCKET!!!'
     server_bufchan.close()
     if sys.version_info < (2, 7):
@@ -78,17 +78,17 @@ def test_close_client_bufchan():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
     client_bufchan = zerorpc.BufferedChannel(client_hbchan)
     client_bufchan.emit('openthat', None)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
     server_bufchan = zerorpc.BufferedChannel(server_hbchan)
     server_bufchan.recv()
 
-    gevent.sleep(3)
+    gevent.sleep(TIME_FACTOR * 3)
     print 'CLOSE CLIENT SOCKET!!!'
     client_bufchan.close()
     if sys.version_info < (2, 7):
@@ -113,15 +113,15 @@ def test_heartbeat_can_open_channel_server_close():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
     client_bufchan = zerorpc.BufferedChannel(client_hbchan)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
     server_bufchan = zerorpc.BufferedChannel(server_hbchan)
 
-    gevent.sleep(3)
+    gevent.sleep(TIME_FACTOR * 3)
     print 'CLOSE SERVER SOCKET!!!'
     server_bufchan.close()
     if sys.version_info < (2, 7):
@@ -146,15 +146,15 @@ def test_heartbeat_can_open_channel_client_close():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
     client_bufchan = zerorpc.BufferedChannel(client_hbchan)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
     server_bufchan = zerorpc.BufferedChannel(server_hbchan)
 
-    gevent.sleep(3)
+    gevent.sleep(TIME_FACTOR * 3)
     print 'CLOSE CLIENT SOCKET!!!'
     client_bufchan.close()
     client.close()
@@ -179,12 +179,12 @@ def test_do_some_req_rep():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
     client_bufchan = zerorpc.BufferedChannel(client_hbchan)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
     server_bufchan = zerorpc.BufferedChannel(server_hbchan)
 
     def client_do():
@@ -225,7 +225,7 @@ def test_do_some_req_rep_lost_server():
     def client_do():
         print 'running'
         client_channel = client.channel()
-        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
         client_bufchan = zerorpc.BufferedChannel(client_hbchan)
         for x in xrange(10):
             client_bufchan.emit('add', (x, x * x))
@@ -246,7 +246,7 @@ def test_do_some_req_rep_lost_server():
     def server_do():
         event = server.recv()
         server_channel = server.channel(event)
-        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
         server_bufchan = zerorpc.BufferedChannel(server_hbchan)
         for x in xrange(10):
             event = server_bufchan.recv()
@@ -273,7 +273,7 @@ def test_do_some_req_rep_lost_client():
 
     def client_do():
         client_channel = client.channel()
-        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
         client_bufchan = zerorpc.BufferedChannel(client_hbchan)
 
         for x in xrange(10):
@@ -289,7 +289,7 @@ def test_do_some_req_rep_lost_client():
     def server_do():
         event = server.recv()
         server_channel = server.channel(event)
-        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
         server_bufchan = zerorpc.BufferedChannel(server_hbchan)
 
         for x in xrange(10):
@@ -323,14 +323,14 @@ def test_do_some_req_rep_client_timeout():
 
     def client_do():
         client_channel = client.channel()
-        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
         client_bufchan = zerorpc.BufferedChannel(client_hbchan)
 
         if sys.version_info < (2, 7):
             def _do_with_assert_raises():
                 for x in xrange(10):
                     client_bufchan.emit('sleep', (x,))
-                    event = client_bufchan.recv(timeout=3)
+                    event = client_bufchan.recv(timeout=TIME_FACTOR * 3)
                     assert event.name == 'OK'
                     assert list(event.args) == [x]
             assert_raises(zerorpc.TimeoutExpired, _do_with_assert_raises)
@@ -338,7 +338,7 @@ def test_do_some_req_rep_client_timeout():
             with assert_raises(zerorpc.TimeoutExpired):
                 for x in xrange(10):
                     client_bufchan.emit('sleep', (x,))
-                    event = client_bufchan.recv(timeout=3)
+                    event = client_bufchan.recv(timeout=TIME_FACTOR * 3)
                     assert event.name == 'OK'
                     assert list(event.args) == [x]
         client_bufchan.close()
@@ -349,7 +349,7 @@ def test_do_some_req_rep_client_timeout():
     def server_do():
         event = server.recv()
         server_channel = server.channel(event)
-        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
         server_bufchan = zerorpc.BufferedChannel(server_hbchan)
 
         if sys.version_info < (2, 7):
@@ -357,7 +357,7 @@ def test_do_some_req_rep_client_timeout():
                 for x in xrange(20):
                     event = server_bufchan.recv()
                     assert event.name == 'sleep'
-                    gevent.sleep(event.args[0])
+                    gevent.sleep(TIME_FACTOR * event.args[0])
                     server_bufchan.emit('OK', event.args)
             assert_raises(zerorpc.LostRemote, _do_with_assert_raises)
         else:
@@ -365,7 +365,7 @@ def test_do_some_req_rep_client_timeout():
                 for x in xrange(20):
                     event = server_bufchan.recv()
                     assert event.name == 'sleep'
-                    gevent.sleep(event.args[0])
+                    gevent.sleep(TIME_FACTOR * event.args[0])
                     server_bufchan.emit('OK', event.args)
         server_bufchan.close()
 
@@ -375,10 +375,6 @@ def test_do_some_req_rep_client_timeout():
     coro_pool.join()
     client.close()
     server.close()
-
-
-class CongestionError(Exception):
-    pass
 
 
 def test_congestion_control_server_pushing():
@@ -392,12 +388,12 @@ def test_congestion_control_server_pushing():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
     client_bufchan = zerorpc.BufferedChannel(client_hbchan)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
     server_bufchan = zerorpc.BufferedChannel(server_hbchan)
 
     def client_do():
@@ -413,26 +409,22 @@ def test_congestion_control_server_pushing():
         if sys.version_info < (2, 7):
             def _do_with_assert_raises():
                 for x in xrange(200):
-                    if not server_bufchan.emit('coucou', x, block=False):
-                        raise CongestionError()  # will fail when x == 1
-            assert_raises(CongestionError, _do_with_assert_raises)
+                    server_bufchan.emit('coucou', x, timeout=TIME_FACTOR * 0)  # will fail when x == 1
+            assert_raises(zerorpc.TimeoutExpired, _do_with_assert_raises)
         else:
-            with assert_raises(CongestionError):
+            with assert_raises(zerorpc.TimeoutExpired):
                 for x in xrange(200):
-                    if not server_bufchan.emit('coucou', x, block=False):
-                        raise CongestionError()  # will fail when x == 1
+                    server_bufchan.emit('coucou', x, timeout=TIME_FACTOR * 0)  # will fail when x == 1
         server_bufchan.emit('coucou', 1)  # block until receiver is ready
         if sys.version_info < (2, 7):
             def _do_with_assert_raises():
                 for x in xrange(2, 200):
-                    if not server_bufchan.emit('coucou', x, block=False):
-                        raise CongestionError()  # will fail when x == 100
-            assert_raises(CongestionError, _do_with_assert_raises)
+                    server_bufchan.emit('coucou', x, timeout=TIME_FACTOR * 0)  # will fail when x == 100
+            assert_raises(zerorpc.TimeoutExpired, _do_with_assert_raises)
         else:
-            with assert_raises(CongestionError):
+            with assert_raises(zerorpc.TimeoutExpired):
                 for x in xrange(2, 200):
-                    if not server_bufchan.emit('coucou', x, block=False):
-                        raise CongestionError()  # will fail when x == 100
+                    server_bufchan.emit('coucou', x, timeout=TIME_FACTOR * 0)  # will fail when x == 100
         for x in xrange(101, 200):
             server_bufchan.emit('coucou', x) # block until receiver is ready
 

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -29,7 +29,7 @@ import sys
 
 from zerorpc import zmq
 import zerorpc
-from testutils import teardown, random_ipc_endpoint
+from testutils import teardown, random_ipc_endpoint, TIME_FACTOR
 
 
 def test_client_server_client_timeout_with_async():
@@ -41,14 +41,14 @@ def test_client_server_client_timeout_with_async():
             return 42
 
         def add(self, a, b):
-            gevent.sleep(10)
+            gevent.sleep(TIME_FACTOR * 10)
             return a + b
 
     srv = MySrv()
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client = zerorpc.Client(timeout=2)
+    client = zerorpc.Client(timeout=TIME_FACTOR * 2)
     client.connect(endpoint)
 
     async_result = client.add(1, 4, async=True)

--- a/tests/test_client_heartbeat.py
+++ b/tests/test_client_heartbeat.py
@@ -26,7 +26,7 @@
 import gevent
 
 import zerorpc
-from testutils import teardown, random_ipc_endpoint
+from testutils import teardown, random_ipc_endpoint, TIME_FACTOR
 
 
 def test_client_server_hearbeat():
@@ -38,13 +38,13 @@ def test_client_server_hearbeat():
             return 42
 
         def slow(self):
-            gevent.sleep(10)
+            gevent.sleep(TIME_FACTOR * 10)
 
-    srv = MySrv(heartbeat=1)
+    srv = MySrv(heartbeat=TIME_FACTOR * 1)
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client = zerorpc.Client(heartbeat=1)
+    client = zerorpc.Client(heartbeat=TIME_FACTOR * 1)
     client.connect(endpoint)
 
     assert client.lolita() == 42
@@ -57,15 +57,15 @@ def test_client_server_activate_heartbeat():
     class MySrv(zerorpc.Server):
 
         def lolita(self):
-            gevent.sleep(3)
+            gevent.sleep(TIME_FACTOR * 3)
             return 42
 
-    srv = MySrv(heartbeat=1)
+    srv = MySrv(heartbeat=TIME_FACTOR * 1)
     srv.bind(endpoint)
     gevent.spawn(srv.run)
-    gevent.sleep(0)
+    gevent.sleep(TIME_FACTOR * 0)
 
-    client = zerorpc.Client(heartbeat=1)
+    client = zerorpc.Client(heartbeat=TIME_FACTOR * 1)
     client.connect(endpoint)
 
     assert client.lolita() == 42
@@ -81,14 +81,14 @@ def test_client_server_passive_hearbeat():
             return 42
 
         def slow(self):
-            gevent.sleep(3)
+            gevent.sleep(TIME_FACTOR * 3)
             return 2
 
-    srv = MySrv(heartbeat=1)
+    srv = MySrv(heartbeat=TIME_FACTOR * 1)
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client = zerorpc.Client(heartbeat=1, passive_heartbeat=True)
+    client = zerorpc.Client(heartbeat=TIME_FACTOR * 1, passive_heartbeat=True)
     client.connect(endpoint)
 
     assert client.slow() == 2
@@ -104,16 +104,16 @@ def test_client_hb_doesnt_linger_on_streaming():
         def iter(self):
             return xrange(42)
 
-    srv = MySrv(heartbeat=1, context=zerorpc.Context())
+    srv = MySrv(heartbeat=TIME_FACTOR * 1, context=zerorpc.Context())
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client1 = zerorpc.Client(endpoint, heartbeat=1, context=zerorpc.Context())
+    client1 = zerorpc.Client(endpoint, heartbeat=TIME_FACTOR * 1, context=zerorpc.Context())
 
     def test_client():
         assert list(client1.iter()) == list(xrange(42))
         print 'sleep 3s'
-        gevent.sleep(3)
+        gevent.sleep(TIME_FACTOR * 3)
 
     gevent.spawn(test_client).join()
 
@@ -126,18 +126,18 @@ def est_client_drop_few():
         def lolita(self):
             return 42
 
-    srv = MySrv(heartbeat=1, context=zerorpc.Context())
+    srv = MySrv(heartbeat=TIME_FACTOR * 1, context=zerorpc.Context())
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client1 = zerorpc.Client(endpoint, heartbeat=1, context=zerorpc.Context())
-    client2 = zerorpc.Client(endpoint, heartbeat=1, context=zerorpc.Context())
-    client3 = zerorpc.Client(endpoint, heartbeat=1, context=zerorpc.Context())
+    client1 = zerorpc.Client(endpoint, heartbeat=TIME_FACTOR * 1, context=zerorpc.Context())
+    client2 = zerorpc.Client(endpoint, heartbeat=TIME_FACTOR * 1, context=zerorpc.Context())
+    client3 = zerorpc.Client(endpoint, heartbeat=TIME_FACTOR * 1, context=zerorpc.Context())
 
     assert client1.lolita() == 42
     assert client2.lolita() == 42
 
-    gevent.sleep(3)
+    gevent.sleep(TIME_FACTOR * 3)
     assert client3.lolita() == 42
 
 
@@ -150,18 +150,18 @@ def test_client_drop_empty_stream():
         def iter(self):
             return []
 
-    srv = MySrv(heartbeat=1, context=zerorpc.Context())
+    srv = MySrv(heartbeat=TIME_FACTOR * 1, context=zerorpc.Context())
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client1 = zerorpc.Client(endpoint, heartbeat=1, context=zerorpc.Context())
+    client1 = zerorpc.Client(endpoint, heartbeat=TIME_FACTOR * 1, context=zerorpc.Context())
 
     def test_client():
         print 'grab iter'
         i = client1.iter()
 
         print 'sleep 3s'
-        gevent.sleep(3)
+        gevent.sleep(TIME_FACTOR * 3)
 
     gevent.spawn(test_client).join()
 
@@ -175,11 +175,11 @@ def test_client_drop_stream():
         def iter(self):
             return xrange(500)
 
-    srv = MySrv(heartbeat=1, context=zerorpc.Context())
+    srv = MySrv(heartbeat=TIME_FACTOR * 1, context=zerorpc.Context())
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client1 = zerorpc.Client(endpoint, heartbeat=1, context=zerorpc.Context())
+    client1 = zerorpc.Client(endpoint, heartbeat=TIME_FACTOR * 1, context=zerorpc.Context())
 
     def test_client():
         print 'grab iter'
@@ -189,6 +189,6 @@ def test_client_drop_stream():
         assert list(next(i) for x in xrange(142)) == list(xrange(142))
 
         print 'sleep 3s'
-        gevent.sleep(3)
+        gevent.sleep(TIME_FACTOR * 3)
 
     gevent.spawn(test_client).join()

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -29,7 +29,7 @@ import sys
 
 from zerorpc import zmq
 import zerorpc
-from testutils import teardown, random_ipc_endpoint
+from testutils import teardown, random_ipc_endpoint, TIME_FACTOR
 
 
 def test_close_server_hbchan():
@@ -43,15 +43,15 @@ def test_close_server_hbchan():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
     client_hbchan.emit('openthat', None)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
     server_hbchan.recv()
 
-    gevent.sleep(3)
+    gevent.sleep(TIME_FACTOR * 3)
     print 'CLOSE SERVER SOCKET!!!'
     server_hbchan.close()
     if sys.version_info < (2, 7):
@@ -76,15 +76,15 @@ def test_close_client_hbchan():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
     client_hbchan.emit('openthat', None)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
     server_hbchan.recv()
 
-    gevent.sleep(3)
+    gevent.sleep(TIME_FACTOR * 3)
     print 'CLOSE CLIENT SOCKET!!!'
     client_hbchan.close()
     if sys.version_info < (2, 7):
@@ -109,13 +109,13 @@ def test_heartbeat_can_open_channel_server_close():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
 
-    gevent.sleep(3)
+    gevent.sleep(TIME_FACTOR * 3)
     print 'CLOSE SERVER SOCKET!!!'
     server_hbchan.close()
     if sys.version_info < (2, 7):
@@ -140,13 +140,13 @@ def test_heartbeat_can_open_channel_client_close():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
 
-    gevent.sleep(3)
+    gevent.sleep(TIME_FACTOR * 3)
     print 'CLOSE CLIENT SOCKET!!!'
     client_hbchan.close()
     client.close()
@@ -171,11 +171,11 @@ def test_do_some_req_rep():
     client = zerorpc.ChannelMultiplexer(client_events, ignore_broadcast=True)
 
     client_channel = client.channel()
-    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+    client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
 
     event = server.recv()
     server_channel = server.channel(event)
-    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+    server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
 
     def client_do():
         for x in xrange(20):
@@ -215,7 +215,7 @@ def test_do_some_req_rep_lost_server():
     def client_do():
         print 'running'
         client_channel = client.channel()
-        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
         for x in xrange(10):
             client_hbchan.emit('add', (x, x * x))
             event = client_hbchan.recv()
@@ -234,7 +234,7 @@ def test_do_some_req_rep_lost_server():
     def server_do():
         event = server.recv()
         server_channel = server.channel(event)
-        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
         for x in xrange(10):
             event = server_hbchan.recv()
             assert event.name == 'add'
@@ -261,7 +261,7 @@ def test_do_some_req_rep_lost_client():
 
     def client_do():
         client_channel = client.channel()
-        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
 
         for x in xrange(10):
             client_hbchan.emit('add', (x, x * x))
@@ -275,7 +275,7 @@ def test_do_some_req_rep_lost_client():
     def server_do():
         event = server.recv()
         server_channel = server.channel(event)
-        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
 
         for x in xrange(10):
             event = server_hbchan.recv()
@@ -309,13 +309,13 @@ def test_do_some_req_rep_client_timeout():
 
     def client_do():
         client_channel = client.channel()
-        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=2)
+        client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
 
         if sys.version_info < (2, 7):
             def _do_with_assert_raises():
                 for x in xrange(10):
                     client_hbchan.emit('sleep', (x,))
-                    event = client_hbchan.recv(timeout=3)
+                    event = client_hbchan.recv(timeout=TIME_FACTOR * 3)
                     assert event.name == 'OK'
                     assert list(event.args) == [x]
             assert_raises(zerorpc.TimeoutExpired, _do_with_assert_raises)
@@ -323,7 +323,7 @@ def test_do_some_req_rep_client_timeout():
             with assert_raises(zerorpc.TimeoutExpired):
                 for x in xrange(10):
                     client_hbchan.emit('sleep', (x,))
-                    event = client_hbchan.recv(timeout=3)
+                    event = client_hbchan.recv(timeout=TIME_FACTOR * 3)
                     assert event.name == 'OK'
                     assert list(event.args) == [x]
         client_hbchan.close()
@@ -333,14 +333,14 @@ def test_do_some_req_rep_client_timeout():
     def server_do():
         event = server.recv()
         server_channel = server.channel(event)
-        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=2)
+        server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
 
         if sys.version_info < (2, 7):
             def _do_with_assert_raises():
                 for x in xrange(20):
                     event = server_hbchan.recv()
                     assert event.name == 'sleep'
-                    gevent.sleep(event.args[0])
+                    gevent.sleep(TIME_FACTOR * event.args[0])
                     server_hbchan.emit('OK', event.args)
             assert_raises(zerorpc.LostRemote, _do_with_assert_raises)
         else:
@@ -348,7 +348,7 @@ def test_do_some_req_rep_client_timeout():
                 for x in xrange(20):
                     event = server_hbchan.recv()
                     assert event.name == 'sleep'
-                    gevent.sleep(event.args[0])
+                    gevent.sleep(TIME_FACTOR * event.args[0])
                     server_hbchan.emit('OK', event.args)
         server_hbchan.close()
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -32,7 +32,7 @@ import sys
 
 from zerorpc import zmq
 import zerorpc
-from testutils import teardown, random_ipc_endpoint
+from testutils import teardown, random_ipc_endpoint, TIME_FACTOR
 
 
 def test_resolve_endpoint():
@@ -94,7 +94,7 @@ def test_resolve_endpoint_events():
             print 'heee'
             return 'world'
 
-    srv = Srv(heartbeat=1, context=c)
+    srv = Srv(heartbeat=TIME_FACTOR * 1, context=c)
     if sys.version_info < (2, 7):
         assert_raises(zmq.ZMQError, srv.bind, 'some_service')
     else:
@@ -106,7 +106,7 @@ def test_resolve_endpoint_events():
     srv.bind('some_service')
     gevent.spawn(srv.run)
 
-    client = zerorpc.Client(heartbeat=1, context=c)
+    client = zerorpc.Client(heartbeat=TIME_FACTOR * 1, context=c)
     client.connect('some_service')
     assert client.hello() == 'world'
 
@@ -373,9 +373,9 @@ def test_task_context_pubsub():
     trigger.clear()
     # We need this retry logic to wait that the subscriber.run coroutine starts
     # reading (the published messages will go to /dev/null until then).
-    for attempt in xrange(0, 10):
+    for attempt in xrange(0, 100):
         c.echo('pub...')
-        if trigger.wait(0.2):
+        if trigger.wait(TIME_FACTOR * 0.2):
             break
 
     subscriber.stop()
@@ -459,7 +459,7 @@ def test_server_inspect_exception_middleware_puller():
 
     barrier.clear()
     client.echo('This is a test which should call the InspectExceptionMiddleware')
-    barrier.wait(timeout=2)
+    barrier.wait(timeout=TIME_FACTOR * 2)
 
     client.close()
     server.close()

--- a/tests/test_middleware_before_after_exec.py
+++ b/tests/test_middleware_before_after_exec.py
@@ -25,7 +25,7 @@
 import gevent
 import zerorpc
 
-from testutils import random_ipc_endpoint
+from testutils import random_ipc_endpoint, TIME_FACTOR
 
 class EchoModule(object):
 
@@ -91,7 +91,7 @@ def test_hook_server_before_exec_puller():
 
     # Test without a middleware
     test_client.echo("test")
-    trigger.wait(timeout=2)
+    trigger.wait(timeout=TIME_FACTOR * 2)
     assert echo_module.last_msg == "echo: test"
     trigger.clear()
 
@@ -100,7 +100,7 @@ def test_hook_server_before_exec_puller():
     zero_ctx.register_middleware(test_middleware)
     assert test_middleware.called == False
     test_client.echo("test with a middleware")
-    trigger.wait(timeout=2)
+    trigger.wait(timeout=TIME_FACTOR * 2)
     assert echo_module.last_msg == "echo: test with a middleware"
     assert test_middleware.called == True
 
@@ -183,7 +183,7 @@ def test_hook_server_after_exec_puller():
 
     # Test without a middleware
     test_client.echo("test")
-    trigger.wait(timeout=2)
+    trigger.wait(timeout=TIME_FACTOR * 2)
     assert echo_module.last_msg == "echo: test"
     trigger.clear()
 
@@ -192,7 +192,7 @@ def test_hook_server_after_exec_puller():
     zero_ctx.register_middleware(test_middleware)
     assert test_middleware.called == False
     test_client.echo("test with a middleware")
-    trigger.wait(timeout=2)
+    trigger.wait(timeout=TIME_FACTOR * 2)
     assert echo_module.last_msg == "echo: test with a middleware"
     assert test_middleware.called == True
     assert test_middleware.request_event_name == 'echo'
@@ -288,7 +288,7 @@ def test_hook_server_after_exec_on_error_puller():
     assert test_middleware.called == False
     try:
         test_client.echo("test with a middleware")
-        trigger.wait(timeout=2)
+        trigger.wait(timeout=TIME_FACTOR * 2)
     except zerorpc.RemoteError:
         pass
     assert echo_module.last_msg == "Raise"

--- a/tests/test_middleware_client.py
+++ b/tests/test_middleware_client.py
@@ -25,7 +25,7 @@
 import gevent
 import zerorpc
 
-from testutils import random_ipc_endpoint
+from testutils import random_ipc_endpoint, TIME_FACTOR
 
 class EchoModule(object):
 
@@ -59,7 +59,7 @@ class EchoModule(object):
 
     def timeout(self, msg):
         self.last_msg = "timeout: " + msg
-        gevent.sleep(2)
+        gevent.sleep(TIME_FACTOR * 2)
 
 def test_hook_client_before_request():
 
@@ -175,7 +175,7 @@ def test_hook_client_after_request_timeout():
     test_server.bind(endpoint)
     test_server_task = gevent.spawn(test_server.run)
 
-    test_client = zerorpc.Client(timeout=1, context=zero_ctx)
+    test_client = zerorpc.Client(timeout=TIME_FACTOR * 1, context=zero_ctx)
     test_client.connect(endpoint)
 
     assert test_middleware.called == False
@@ -211,7 +211,7 @@ def test_hook_client_after_request_remote_error():
     test_server.bind(endpoint)
     test_server_task = gevent.spawn(test_server.run)
 
-    test_client = zerorpc.Client(timeout=1, context=zero_ctx)
+    test_client = zerorpc.Client(timeout=TIME_FACTOR * 1, context=zero_ctx)
     test_client.connect(endpoint)
 
     assert test_middleware.called == False
@@ -234,7 +234,7 @@ def test_hook_client_after_request_remote_error_stream():
     test_server.bind(endpoint)
     test_server_task = gevent.spawn(test_server.run)
 
-    test_client = zerorpc.Client(timeout=1, context=zero_ctx)
+    test_client = zerorpc.Client(timeout=TIME_FACTOR * 1, context=zero_ctx)
     test_client.connect(endpoint)
 
     assert test_middleware.called == False

--- a/tests/test_reqstream.py
+++ b/tests/test_reqstream.py
@@ -26,7 +26,7 @@
 import gevent
 
 import zerorpc
-from testutils import teardown, random_ipc_endpoint
+from testutils import teardown, random_ipc_endpoint, TIME_FACTOR
 
 
 def test_rcp_streaming():
@@ -42,11 +42,11 @@ def test_rcp_streaming():
         def xrange(self, max):
             return xrange(max)
 
-    srv = MySrv(heartbeat=2)
+    srv = MySrv(heartbeat=TIME_FACTOR * 2)
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client = zerorpc.Client(heartbeat=2)
+    client = zerorpc.Client(heartbeat=TIME_FACTOR * 2)
     client.connect(endpoint)
 
     r = client.range(10)
@@ -56,7 +56,7 @@ def test_rcp_streaming():
     assert getattr(r, 'next', None) is not None
     l = []
     print 'wait 4s for fun'
-    gevent.sleep(4)
+    gevent.sleep(TIME_FACTOR * 4)
     for x in r:
         l.append(x)
     assert l == range(10)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -29,7 +29,7 @@ import sys
 
 from zerorpc import zmq
 import zerorpc
-from testutils import teardown, random_ipc_endpoint
+from testutils import teardown, random_ipc_endpoint, TIME_FACTOR
 
 
 def test_server_manual():
@@ -99,14 +99,14 @@ def test_client_server_client_timeout():
             return 42
 
         def add(self, a, b):
-            gevent.sleep(10)
+            gevent.sleep(TIME_FACTOR * 10)
             return a + b
 
     srv = MySrv()
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client = zerorpc.Client(timeout=2)
+    client = zerorpc.Client(timeout=TIME_FACTOR * 2)
     client.connect(endpoint)
 
     if sys.version_info < (2, 7):
@@ -130,7 +130,7 @@ def test_client_server_exception():
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client = zerorpc.Client(timeout=2)
+    client = zerorpc.Client(timeout=TIME_FACTOR * 2)
     client.connect(endpoint)
 
     if sys.version_info < (2, 7):
@@ -157,7 +157,7 @@ def test_client_server_detailed_exception():
     srv.bind(endpoint)
     gevent.spawn(srv.run)
 
-    client = zerorpc.Client(timeout=2)
+    client = zerorpc.Client(timeout=TIME_FACTOR * 2)
     client.connect(endpoint)
 
     if sys.version_info < (2, 7):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -52,3 +52,9 @@ def skip(reason):
             raise nose.exc.SkipTest(reason)
         return wrap
     return _skip
+
+try:
+    TIME_FACTOR = float(os.environ.get('ZPC_TEST_TIME_FACTOR'))
+    print 'ZPC_TEST_TIME_FACTOR:', TIME_FACTOR
+except TypeError:
+    TIME_FACTOR = 1.0


### PR DESCRIPTION
One can set the env variable ZPC_TEST_TIME_FACTOR to something smaller
than 1.0 in order to speedup testing. At some really small values, unit
tests about timeouts are likely to fail!

Example:
$ ZPC_TEST_TIME_FACTOR=0.01 nosetests