### PR TITLE
Fix some `print` and `except` statements for 3.x.

### DIFF
--- a/zerorpc/cli.py
+++ b/zerorpc/cli.py
@@ -82,7 +82,7 @@ parser.add_argument('params', nargs='*',
 def setup_links(args, socket):
     if args.bind:
         for endpoint in args.bind:
-            print 'binding to "{0}"'.format(endpoint)
+            print('binding to "{0}"'.format(endpoint))
             socket.bind(endpoint)
     addresses = []
     if args.address:
@@ -90,7 +90,7 @@ def setup_links(args, socket):
     if args.connect:
         addresses.extend(args.connect)
     for endpoint in addresses:
-        print 'connecting to "{0}"'.format(endpoint)
+        print('connecting to "{0}"'.format(endpoint))
         socket.connect(endpoint)
 
 
@@ -110,7 +110,7 @@ def run_server(args):
 
     server = zerorpc.Server(server_obj, heartbeat=args.heartbeat)
     setup_links(args, server)
-    print 'serving "{0}"'.format(server_obj_path)
+    print('serving "{0}"'.format(server_obj_path))
     return server.run()
 
 
@@ -214,16 +214,16 @@ def run_client(args):
                 long_doc=False, include_argspec=args.inspect)
         if args.inspect:
             for (name, doc) in detailled_methods:
-                print name
+                print(name)
         else:
             for (name, doc) in detailled_methods:
-                print '{0} {1}'.format(name.ljust(longest_name_len), doc)
+                print('{0} {1}'.format(name.ljust(longest_name_len), doc))
         return
     if args.inspect:
         (longest_name_len, detailled_methods) = zerorpc_inspect(client,
                 method=args.command)
         (name, doc) = detailled_methods[0]
-        print '\n{0}\n\n{1}\n'.format(name, doc)
+        print('\n{0}\n\n{1}\n'.format(name, doc))
         return
     if args.json:
         call_args = [json.loads(x) for x in args.params]

--- a/zerorpc/gevent_zmq.py
+++ b/zerorpc/gevent_zmq.py
@@ -100,7 +100,7 @@ class Socket(_zmq.Socket):
         while True:
             try:
                 return super(Socket, self).connect(*args, **kwargs)
-            except _zmq.ZMQError, e:
+            except _zmq.ZMQError as e:
                 if e.errno not in (_zmq.EAGAIN, errno.EINTR):
                     raise
 
@@ -122,7 +122,7 @@ class Socket(_zmq.Socket):
                 # send and recv on the socket.
                 self._on_state_changed()
                 return msg
-            except _zmq.ZMQError, e:
+            except _zmq.ZMQError as e:
                 if e.errno not in (_zmq.EAGAIN, errno.EINTR):
                     raise
             self._writable.clear()
@@ -162,7 +162,7 @@ class Socket(_zmq.Socket):
                 # send and recv on the socket.
                 self._on_state_changed()
                 return msg
-            except _zmq.ZMQError, e:
+            except _zmq.ZMQError as e:
                 if e.errno not in (_zmq.EAGAIN, errno.EINTR):
                     raise
             self._readable.clear()


### PR DESCRIPTION
- With these changes, and MichalMazurek's `gevent` fork
  (from [#38](https://github.com/surfly/gevent/issues/38)),
  I'm able to build `zerorpc` for Python 3.4.

- No promises on whether it actually starts up, much less works properly. I was just looking to see how far this library was from 3.x compatibility, and this was all it took to get `pip3 install .` to work.