### PR TITLE
Use correct relative imports for gevent_zmq

### DIFF
--- a/zerorpc/cli.py
+++ b/zerorpc/cli.py
@@ -82,7 +82,7 @@ parser.add_argument('params', nargs='*',
 def setup_links(args, socket):
     if args.bind:
         for endpoint in args.bind:
-            print 'binding to "{0}"'.format(endpoint)
+            print('binding to "{0}"'.format(endpoint))
             socket.bind(endpoint)
     addresses = []
     if args.address:
@@ -90,7 +90,7 @@ def setup_links(args, socket):
     if args.connect:
         addresses.extend(args.connect)
     for endpoint in addresses:
-        print 'connecting to "{0}"'.format(endpoint)
+        print('connecting to "{0}"'.format(endpoint))
         socket.connect(endpoint)
 
 
@@ -110,7 +110,7 @@ def run_server(args):
 
     server = zerorpc.Server(server_obj, heartbeat=args.heartbeat)
     setup_links(args, server)
-    print 'serving "{0}"'.format(server_obj_path)
+    print('serving "{0}"'.format(server_obj_path))
     return server.run()
 
 
@@ -214,16 +214,16 @@ def run_client(args):
                 long_doc=False, include_argspec=args.inspect)
         if args.inspect:
             for (name, doc) in detailled_methods:
-                print name
+                print(name)
         else:
             for (name, doc) in detailled_methods:
-                print '{0} {1}'.format(name.ljust(longest_name_len), doc)
+                print('{0} {1}'.format(name.ljust(longest_name_len), doc))
         return
     if args.inspect:
         (longest_name_len, detailled_methods) = zerorpc_inspect(client,
                 method=args.command)
         (name, doc) = detailled_methods[0]
-        print '\n{0}\n\n{1}\n'.format(name, doc)
+        print('\n{0}\n\n{1}\n'.format(name, doc))
         return
     if args.json:
         call_args = [json.loads(x) for x in args.params]

--- a/zerorpc/context.py
+++ b/zerorpc/context.py
@@ -26,7 +26,7 @@
 import uuid
 import random
 
-import gevent_zmq as zmq
+from . import gevent_zmq as zmq
 
 
 class Context(zmq.Context):

--- a/zerorpc/core.py
+++ b/zerorpc/core.py
@@ -31,14 +31,14 @@ import gevent.event
 import gevent.local
 import gevent.lock
 
-import gevent_zmq as zmq
+from . import gevent_zmq as zmq
 from .exceptions import TimeoutExpired, RemoteError, LostRemote
 from .channel import ChannelMultiplexer, BufferedChannel
 from .socket import SocketBase
 from .heartbeat import HeartBeatOnChannel
 from .context import Context
 from .decorators import DecoratorBase, rep
-import patterns
+from . import patterns
 from logging import getLogger
 
 logger = getLogger(__name__)

--- a/zerorpc/events.py
+++ b/zerorpc/events.py
@@ -31,7 +31,7 @@ import gevent.local
 import gevent.lock
 
 
-import gevent_zmq as zmq
+from . import gevent_zmq as zmq
 from .context import Context
 
 

--- a/zerorpc/gevent_zmq.py
+++ b/zerorpc/gevent_zmq.py
@@ -100,7 +100,7 @@ class Socket(_zmq.Socket):
         while True:
             try:
                 return super(Socket, self).connect(*args, **kwargs)
-            except _zmq.ZMQError, e:
+            except _zmq.ZMQError as e:
                 if e.errno not in (_zmq.EAGAIN, errno.EINTR):
                     raise
 
@@ -122,7 +122,7 @@ class Socket(_zmq.Socket):
                 # send and recv on the socket.
                 self._on_state_changed()
                 return msg
-            except _zmq.ZMQError, e:
+            except _zmq.ZMQError as e:
                 if e.errno not in (_zmq.EAGAIN, errno.EINTR):
                     raise
             self._writable.clear()
@@ -162,7 +162,7 @@ class Socket(_zmq.Socket):
                 # send and recv on the socket.
                 self._on_state_changed()
                 return msg
-            except _zmq.ZMQError, e:
+            except _zmq.ZMQError as e:
                 if e.errno not in (_zmq.EAGAIN, errno.EINTR):
                     raise
             self._readable.clear()


### PR DESCRIPTION
Also includes the commit from https://github.com/dotcloud/zerorpc-python/pull/109 since this is to further python3 support.

There is still an error that comes up when the server is run:
python3 zerorpc-python/bin/zerorpc --server --bind tcp://*:1234 time

Traceback (most recent call last):
  File "/home/fahhem/projects/chainreaction/v1/rpc_layer/tmp1/lib/python3.4/site-packages/gevent/greenlet.py", line 340, in run
    result = self._run(*self.args, **self.kwargs)
  File "zerorpc-python/zerorpc/events.py", line 54, in _sender
    for parts in self._send_queue:
TypeError: iter() returned non-iterator of type 'Channel'
<Greenlet at 0x7f389cf97cc0: <bound method Sender._sender of <zerorpc.events.Sender object at 0x7f389cd1eba8>>> failed with TypeError

Not the best result, but at least it gets past the import.