### PR TITLE
add unicode decoding for client side to resolve non-English string de…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ except ImportError:
 
 requirements = [
     'gevent>=1.0',
-    'msgpack-python',
+    'msgpack-python>=0.4.0',
     'pyzmq>=13.1.0'
 ]
 if sys.version_info < (2, 7):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -169,3 +169,59 @@ def test_events_push_pull():
         print event
         assert event.name == 'myevent'
         assert list(event.args) == [x]
+
+
+def test_msgpack():
+    context = zerorpc.Context()
+    event = zerorpc.Event('myevent', ('a',), context=context)
+    print event
+    assert type(event.name) == str
+    for key in event.header.keys():
+        assert type(key) == str
+    assert type(event.header['message_id']) == str
+    assert type(event.args[0]) == str
+
+    packed = event.pack()
+    event = event.unpack(packed)
+    print event
+    assert type(event.name) == str
+    for key in event.header.keys():
+        assert type(key) == str
+    assert type(event.header['message_id']) == str
+    assert type(event.args[0]) == str
+
+    event = zerorpc.Event('myevent', (u'a',), context=context)
+    print event
+    assert type(event.name) == str
+    for key in event.header.keys():
+        assert type(key) == str
+    assert type(event.header['message_id']) == str
+    assert type(event.args[0]) == unicode
+
+    packed = event.pack()
+    event = event.unpack(packed)
+    print event
+    assert type(event.name) == str
+    for key in event.header.keys():
+        assert type(key) == str
+    assert type(event.header['message_id']) == str
+    assert type(event.args[0]) == unicode
+
+    event = zerorpc.Event('myevent', (u'a', 'b'), context=context)
+    print event
+    assert type(event.name) == str
+    for key in event.header.keys():
+        assert type(key) == str
+    assert type(event.header['message_id']) == str
+    assert type(event.args[0]) == unicode
+    assert type(event.args[1]) == str
+
+    packed = event.pack()
+    event = event.unpack(packed)
+    print event
+    assert type(event.name) == str
+    for key in event.header.keys():
+        assert type(key) == str
+    assert type(event.header['message_id']) == str
+    assert type(event.args[0]) == unicode
+    assert type(event.args[1]) == str

--- a/zerorpc/events.py
+++ b/zerorpc/events.py
@@ -189,11 +189,11 @@ class Event(object):
         self._identity = v
 
     def pack(self):
-        return msgpack.Packer().pack((self._header, self._name, self._args))
+        return msgpack.Packer(use_bin_type=True).pack((self._header, self._name, self._args))
 
     @staticmethod
     def unpack(blob):
-        unpacker = msgpack.Unpacker()
+        unpacker = msgpack.Unpacker(encoding='utf-8')
         unpacker.feed(blob)
         unpacked_msg = unpacker.unpack()
 


### PR DESCRIPTION
…code issues
All string object received by zerorpc is ``str`` type. With English string, this works fine and has no issues at all. But with non-English string, a ``unicode`` object is used instead. It will cause some issue when using ``str`` to interact with ``unicode`` object. 
It is possible to decode string to unicode outside the zerorpc lib, but the most convenient and speedy way is tell ``msgpack`` to use ``unicode`` instead of ``str``. This commit gives the possibility to change the way ``msgpack`` works. It will still use ``str`` for default and gives an option for ``unicode``.