### PR TITLE
Fixed SyntaxError when installing with pip3.4

### DIFF
--- a/zerorpc/gevent_zmq.py
+++ b/zerorpc/gevent_zmq.py
@@ -100,7 +100,7 @@ class Socket(_zmq.Socket):
         while True:
             try:
                 return super(Socket, self).connect(*args, **kwargs)
-            except _zmq.ZMQError, e:
+            except _zmq.ZMQError as e:
                 if e.errno not in (_zmq.EAGAIN, errno.EINTR):
                     raise
 
@@ -122,7 +122,7 @@ class Socket(_zmq.Socket):
                 # send and recv on the socket.
                 self._on_state_changed()
                 return msg
-            except _zmq.ZMQError, e:
+            except _zmq.ZMQError as e:
                 if e.errno not in (_zmq.EAGAIN, errno.EINTR):
                     raise
             self._writable.clear()
@@ -162,7 +162,7 @@ class Socket(_zmq.Socket):
                 # send and recv on the socket.
                 self._on_state_changed()
                 return msg
-            except _zmq.ZMQError, e:
+            except _zmq.ZMQError as e:
                 if e.errno not in (_zmq.EAGAIN, errno.EINTR):
                     raise
             self._readable.clear()


### PR DESCRIPTION
That's probably not a big deal as gevent for Python 3 still not supported. Anyways, I've just seen a traceback when installed zerorpc via pip:

```
Installing collected packages: zerorpc
  Running setup.py install for zerorpc
      File "/usr/local/lib/python3.4/site-packages/zerorpc/cli.py", line 89
        print 'binding to "{0}"'.format(endpoint)
                               ^
    SyntaxError: invalid syntax
    
      File "/usr/local/lib/python3.4/site-packages/zerorpc/gevent_zmq.py", line 103
        except _zmq.ZMQError, e:
                            ^
    SyntaxError: invalid syntax
    
    Installing zerorpc script to /usr/local/bin
Successfully installed zerorpc
Cleaning up...
```

It's better to have this fixed.