### PR TITLE
Added TypeError to events.Events __del__

### DIFF
--- a/zerorpc/events.py
+++ b/zerorpc/events.py
@@ -261,7 +261,7 @@ class Events(ChannelBase):
         try:
             if not self._socket.closed:
                 self.close()
-        except AttributeError:
+        except (AttributeError, TypeError):
             pass
 
     def close(self):


### PR DESCRIPTION
On interpreter shutdown you may hit TypeError("'NoneType' object is not callable",)

It fixes #138 