### PR TITLE
fixes encoding problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from io import open
+from past.builtins import execfile
 
-# execfile() doesn't exist in Python 3, this way we are compatible with both.
-exec(compile(open('zerorpc/version.py', encoding='utf8').read(), 'zerorpc/version.py', 'exec'))
+execfile('zerorpc/version.py')
 
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from past.builtins import execfile
-
-execfile('zerorpc/version.py')
-
 import sys
 
+if sys.version_info < (3, 0):
+    execfile('zerorpc/version.py')
+else:
+    exec(compile(open('zerorpc/version.py', encoding='utf8').read(), 'zerorpc/version.py', 'exec'))
 
 try:
     from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from io import open
+
 # execfile() doesn't exist in Python 3, this way we are compatible with both.
 exec(compile(open('zerorpc/version.py', encoding='utf8').read(), 'zerorpc/version.py', 'exec'))
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@
 # SOFTWARE.
 
 # execfile() doesn't exist in Python 3, this way we are compatible with both.
-exec(compile(open('zerorpc/version.py').read(), 'zerorpc/version.py', 'exec'))
+exec(compile(open('zerorpc/version.py', encoding='utf8').read(), 'zerorpc/version.py', 'exec'))
 
 import sys
 


### PR DESCRIPTION
On a dockerized Ubuntu Xenial Python 3.5.2 installation`setup.py` fails with an encoding problem. This seems to fix it.