### PR TITLE
Fix setup.py in python2.6 and setuptools 0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ if sys.version_info < (2, 7):
     requirements.append('argparse')
 
 if sys.version_info < (2, 7):
-    requirements.append('gevent==1.1.*')
+    requirements.append('gevent>=1.1.0,<1.2.0')
 elif sys.version_info < (3, 0):
     requirements.append('gevent>=1.0')
 else:


### PR DESCRIPTION
In python2.6, the setuptools version is '0.6' which do not support wild-card in
version. The result is pip install failed. This patch fix it.

The failed installation logs:

```
You are using pip version 7.1.0, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Collecting zerorpc
/usr/lib/python2.6/site-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:90: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
  Downloading zerorpc-0.6.1.tar.gz
    Complete output from command python setup.py egg_info:
    error in zerorpc setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
```