### PR TITLE
If functor's __name__ is not available then just stringify it

### DIFF
--- a/zerorpc/decorators.py
+++ b/zerorpc/decorators.py
@@ -33,7 +33,7 @@ class DecoratorBase(object):
     def __init__(self, functor):
         self._functor = functor
         self.__doc__ = functor.__doc__
-        self.__name__ = functor.__name__
+        self.__name__ = getattr(functor, "__name__", str(functor))
 
     def __get__(self, instance, type_instance=None):
         if instance is None:


### PR DESCRIPTION
ZeroRPC was throwing an error when the __name__ attribute wasn't available on an attribute of the main class being wrapped by the ZeroRPC server.

Specifically, I was using it like this:

`server = zerorpc.Server(myClass())`

where `myClass` had an init method like so:

```
def __init__(self):
    self.myVar = myThing
```

where `myThing` was a `Model` from the keras library. keras's `Model`s do not have a `__name__` attribute, leading to an error which crashed the ZeroRPC server.

My solution is, instead of assuming every functor passed in to `DecoratorBase` has a `__name__`, try using `__name__` but fall back to a stringified version of the functor if `__name__` isn't available.

Please let me know what you think.

Thanks!