### PR TITLE
Integrated msgpack-numpy for serializing numpy arrays

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ except ImportError:
 requirements = [
     'msgpack>=0.5.2',
     'pyzmq>=13.1.0',
+    'msgpack-numpy>=0.4.3',
     'future',
 ]
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -197,3 +197,30 @@ def test_msgpack():
     assert isinstance(event.header[u'message_id'], bytes)
     assert isinstance(event.header[u'v'], int)
     assert isinstance(event.args[0], str)
+
+
+def test_msgpack_numpy():
+    import numpy as np
+    context = zerorpc.Context()
+    test_array = np.arange(10)
+    event = zerorpc.Event(u'myevent', (test_array,), context=context)
+    print(event)
+    # note here that str is an unicode string in all Python version (thanks to
+    # the builtin str import).
+    assert isinstance(event.name, str)
+    for key in event.header.keys():
+        assert isinstance(key, str)
+    assert isinstance(event.header[u'message_id'], bytes)
+    assert isinstance(event.header[u'v'], int)
+    assert isinstance(event.args[0], np.ndarray)
+
+    packed = event.pack()
+    event = event.unpack(packed)
+    print(event)
+    assert isinstance(event.name, str)
+    for key in event.header.keys():
+        assert isinstance(key, str)
+    assert isinstance(event.header[u'message_id'], bytes)
+    assert isinstance(event.header[u'v'], int)
+    assert isinstance(event.args[0], np.ndarray)
+    assert np.array_equal(test_array, event.args[0])

--- a/zerorpc/events.py
+++ b/zerorpc/events.py
@@ -28,6 +28,9 @@ from builtins import str
 from builtins import range
 
 import msgpack
+import msgpack_numpy as m
+m.patch()  # Monkeypatching msgpack to handle Numpy
+
 import gevent.pool
 import gevent.queue
 import gevent.event


### PR DESCRIPTION
This enables zerorpc to use numpy arrays as arguments or return values. 

The whole patch is just a simple addition of  [msgpack-numpy](https://github.com/lebedov/msgpack-numpy) using the monkey-patch method.

Worked fine in both tests and real-life use.

Disadvantages:

- introduces numpy into the project dependency tree
- as I'm not affiliated with the msgpack-numpy development, I'm have no idea how much is the monkey-patching approach future-proof or safe.