### PR TITLE
Using trusty as distro for python 2.6 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
     fi
   - "pip install nose $PYZMQ"
   - pip install .
+  - pip freeze
 script:
   - if [ $TRAVIS_PYTHON_VERSION != '2.6' ]; then
     flake8 --ignore=E501,E128 zerorpc bin;


### PR DESCRIPTION
Travis changed the default distro to Xenial which doesn't have python
2.6 environment.