### PR TITLE
core: handle both "async" and "asynchronous" in remote calls

### DIFF
--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -53,7 +53,7 @@ def test_client_server_client_timeout_with_async():
     client = zerorpc.Client(timeout=TIME_FACTOR * 2)
     client.connect(endpoint)
 
-    async_result = client.add(1, 4, async=True)
+    async_result = client.add(1, 4, async_=True)
 
     if sys.version_info < (2, 7):
         def _do_with_assert_raises():
@@ -84,8 +84,8 @@ def test_client_server_with_async():
     client = zerorpc.Client()
     client.connect(endpoint)
 
-    async_result = client.lolita(async=True)
+    async_result = client.lolita(async_=True)
     assert async_result.get() == 42
 
-    async_result = client.add(1, 4, async=True)
+    async_result = client.add(1, 4, async_=True)
     assert async_result.get() == 5

--- a/zerorpc/core.py
+++ b/zerorpc/core.py
@@ -266,7 +266,10 @@ class ClientBase(object):
         self._context.hook_client_before_request(request_event)
         bufchan.emit_event(request_event)
 
-        if kargs.get('async', False) is False:
+        # In python 3.7, "async" is a reserved keyword, clients should now use
+        # "async_": support both for the time being
+        if (kargs.get('async', False) is False and
+            kargs.get('async_', False) is False):
             return self._process_response(request_event, bufchan, timeout)
 
         async_result = gevent.event.AsyncResult()


### PR DESCRIPTION
Python 3.7 made "async" a reserved keyword: this causes a syntax
error when passing "async" as a named parameter in remote procedure
calls. Make ClientBase.__call__() understand both "async" and
"asynchronous" so we don't break our binary interface with older
clients.

Fixes: #239
Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>