### PR TITLE
try collections.abc instead of collections for Python >= 3.4

### DIFF
--- a/tests/test_reqstream.py
+++ b/tests/test_reqstream.py
@@ -28,10 +28,16 @@ from __future__ import absolute_import
 from builtins import range
 
 import gevent
-import collections
 
 import zerorpc
 from .testutils import teardown, random_ipc_endpoint, TIME_FACTOR
+
+try:
+    # Try collections.abc for 3.4+
+    from collections.abc import Iterator
+except ImportError:
+    # Fallback to collections for Python 2
+    from collections import Iterator
 
 
 def test_rcp_streaming():
@@ -58,7 +64,7 @@ def test_rcp_streaming():
     assert list(r) == list(range(10))
 
     r = client.xrange(10)
-    assert isinstance(r, collections.Iterator)
+    assert isinstance(r, Iterator)
     l = []
     print('wait 4s for fun')
     gevent.sleep(TIME_FACTOR * 4)

--- a/zerorpc/cli.py
+++ b/zerorpc/cli.py
@@ -33,10 +33,16 @@ import sys
 import inspect
 import os
 import logging
-import collections
 from pprint import pprint
 
 import zerorpc
+
+try:
+    # Try collections.abc for 3.4+
+    from collections.abc import Iterator
+except ImportError:
+    # Fallback to collections for Python 2
+    from collections import Iterator
 
 
 parser = argparse.ArgumentParser(
@@ -267,7 +273,7 @@ def run_client(args):
     else:
         call_args = args.params
     results = client(args.command, *call_args)
-    if not isinstance(results, collections.Iterator):
+    if not isinstance(results, Iterator):
         if args.print_json:
             json.dump(results, sys.stdout)
         else:


### PR DESCRIPTION
Kill a depreciation warning by importing "collections.abc" and
fallback to "collections" on failure in order to maintain support
for older versions of Python.

Fixes: #231
Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>