### PR TITLE
Fix flake8 warnings/errors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,6 @@ commands =
 passenv = ZPC_TEST_TIME_FACTOR
 
 [flake8]
-ignore = E501,E128
+ignore = E501,E128,W503
 filename = *.py,zerorpc
 exclude = tests,.git,dist,doc,*.egg-info,__pycache__,setup.py

--- a/zerorpc/channel.py
+++ b/zerorpc/channel.py
@@ -232,7 +232,7 @@ class BufferedChannel(ChannelBase):
         self._remote_queue_open_slots -= 1
         try:
             self._channel.emit_event(event)
-        except:
+        except Exception:
             self._remote_queue_open_slots += 1
             raise
 

--- a/zerorpc/core.py
+++ b/zerorpc/core.py
@@ -78,8 +78,8 @@ class ServerBase(object):
         server_methods = set(k for k in dir(cls) if not k.startswith('_'))
         return dict((k, getattr(methods, k))
                     for k in dir(methods)
-                    if callable(getattr(methods, k)) and
-                    not k.startswith('_') and k not in server_methods
+                    if callable(getattr(methods, k))
+                    and not k.startswith('_') and k not in server_methods
                     )
 
     @staticmethod
@@ -268,8 +268,8 @@ class ClientBase(object):
 
         # In python 3.7, "async" is a reserved keyword, clients should now use
         # "async_": support both for the time being
-        if (kargs.get('async', False) is False and
-            kargs.get('async_', False) is False):
+        if (kargs.get('async', False) is False
+                and kargs.get('async_', False) is False):
             return self._process_response(request_event, bufchan, timeout)
 
         async_result = gevent.event.AsyncResult()

--- a/zerorpc/events.py
+++ b/zerorpc/events.py
@@ -67,13 +67,13 @@ class SequentialSender(object):
         for i in range(len(parts) - 1):
             try:
                 self._socket.send(parts[i], copy=False, flags=zmq.SNDMORE)
-            except (gevent.GreenletExit, gevent.Timeout) as e:
+            except (gevent.GreenletExit, gevent.Timeout):
                 if i == 0:
                     raise
                 self._socket.send(parts[i], copy=False, flags=zmq.SNDMORE)
         try:
             self._socket.send(parts[-1], copy=False)
-        except (gevent.GreenletExit, gevent.Timeout) as e:
+        except (gevent.GreenletExit, gevent.Timeout):
             self._socket.send(parts[-1], copy=False)
         if e:
             raise e
@@ -97,7 +97,7 @@ class SequentialReceiver(object):
         while True:
             try:
                 part = self._socket.recv(copy=False)
-            except (gevent.GreenletExit, gevent.Timeout) as e:
+            except (gevent.GreenletExit, gevent.Timeout):
                 if len(parts) == 0:
                     raise
                 part = self._socket.recv(copy=False)


### PR DESCRIPTION
The following warnings/errors are reported with HEAD (99ee6e4)
```
zerorpc/channel.py:235:9: E722 do not use bare 'except'
zerorpc/core.py:81:54: W504 line break after binary operator
zerorpc/core.py:271:48: W504 line break after binary operator
zerorpc/core.py:272:13: E129 visually indented line with same indent as next logical line
zerorpc/events.py:70:13: F841 local variable 'e' is assigned to but never used
zerorpc/events.py:76:9: F841 local variable 'e' is assigned to but never used
zerorpc/events.py:100:13: F841 local variable 'e' is assigned to but never used
```