### PR TITLE
no longer claim/test support for Python 2.6/2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: trusty
 sudo: false
 language: python
 python:
-  - 2.6
-  - 2.7
   - 3.4
   - 3.5
 env:

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,7 @@
 
 import sys
 
-if sys.version_info < (3, 0):
-    execfile('zerorpc/version.py')
-else:
-    exec(compile(open('zerorpc/version.py', encoding='utf8').read(), 'zerorpc/version.py', 'exec'))
+exec(compile(open('zerorpc/version.py', encoding='utf8').read(), 'zerorpc/version.py', 'exec'))
 
 try:
     from setuptools import setup
@@ -36,20 +33,11 @@ except ImportError:
 
 
 requirements = [
+    'gevent>=1.1',
     'msgpack>=0.5.2',
     'pyzmq>=13.1.0',
     'future',
 ]
-
-if sys.version_info < (2, 7):
-    requirements.append('argparse')
-
-if sys.version_info < (2, 7):
-    requirements.append('gevent>=1.1.0,<1.2.0')
-elif sys.version_info < (3, 0):
-    requirements.append('gevent>=1.0')
-else:
-    requirements.append('gevent>=1.1')
 
 with open("README.rst", "r") as fh:
     long_description = fh.read()
@@ -75,8 +63,6 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
     ),
 )

--- a/tests/test_buffered_channel.py
+++ b/tests/test_buffered_channel.py
@@ -60,11 +60,8 @@ def test_close_server_bufchan():
     gevent.sleep(TIME_FACTOR * 3)
     print('CLOSE SERVER SOCKET!!!')
     server_bufchan.close()
-    if sys.version_info < (2, 7):
-        pytest.raises(zerorpc.LostRemote, client_bufchan.recv)
-    else:
-        with pytest.raises(zerorpc.LostRemote):
-            client_bufchan.recv()
+    with pytest.raises(zerorpc.LostRemote):
+        client_bufchan.recv()
     print('CLIENT LOST SERVER :)')
     client_bufchan.close()
     server.close()
@@ -95,11 +92,8 @@ def test_close_client_bufchan():
     gevent.sleep(TIME_FACTOR * 3)
     print('CLOSE CLIENT SOCKET!!!')
     client_bufchan.close()
-    if sys.version_info < (2, 7):
-        pytest.raises(zerorpc.LostRemote, client_bufchan.recv)
-    else:
-        with pytest.raises(zerorpc.LostRemote):
-            client_bufchan.recv()
+    with pytest.raises(zerorpc.LostRemote):
+        client_bufchan.recv()
     print('SERVER LOST CLIENT :)')
     server_bufchan.close()
     server.close()
@@ -128,11 +122,8 @@ def test_heartbeat_can_open_channel_server_close():
     gevent.sleep(TIME_FACTOR * 3)
     print('CLOSE SERVER SOCKET!!!')
     server_bufchan.close()
-    if sys.version_info < (2, 7):
-        pytest.raises(zerorpc.LostRemote, client_bufchan.recv)
-    else:
-        with pytest.raises(zerorpc.LostRemote):
-            client_bufchan.recv()
+    with pytest.raises(zerorpc.LostRemote):
+        client_bufchan.recv()
     print('CLIENT LOST SERVER :)')
     client_bufchan.close()
     server.close()
@@ -169,11 +160,8 @@ def test_heartbeat_can_open_channel_client_close():
     print('CLOSE CLIENT SOCKET!!!')
     client_bufchan.close()
     client.close()
-    if sys.version_info < (2, 7):
-        pytest.raises(zerorpc.LostRemote, server_coro.get)
-    else:
-        with pytest.raises(zerorpc.LostRemote):
-            server_coro.get()
+    with pytest.raises(zerorpc.LostRemote):
+        server_coro.get()
     print('SERVER LOST CLIENT :)')
     server.close()
 
@@ -243,11 +231,8 @@ def test_do_some_req_rep_lost_server():
             assert event.name == 'OK'
             assert list(event.args) == [x + x * x]
         client_bufchan.emit('add', (x, x * x))
-        if sys.version_info < (2, 7):
-            pytest.raises(zerorpc.LostRemote, client_bufchan.recv)
-        else:
-            with pytest.raises(zerorpc.LostRemote):
-                client_bufchan.recv()
+        with pytest.raises(zerorpc.LostRemote):
+            client_bufchan.recv()
         client_bufchan.close()
 
     coro_pool = gevent.pool.Pool()
@@ -307,11 +292,8 @@ def test_do_some_req_rep_lost_client():
             assert event.name == 'add'
             server_bufchan.emit('OK', (sum(event.args),))
 
-        if sys.version_info < (2, 7):
-            pytest.raises(zerorpc.LostRemote, server_bufchan.recv)
-        else:
-            with pytest.raises(zerorpc.LostRemote):
-                server_bufchan.recv()
+        with pytest.raises(zerorpc.LostRemote):
+            server_bufchan.recv()
         server_bufchan.close()
 
     coro_pool.spawn(server_do)
@@ -336,21 +318,12 @@ def test_do_some_req_rep_client_timeout():
         client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
         client_bufchan = zerorpc.BufferedChannel(client_hbchan)
 
-        if sys.version_info < (2, 7):
-            def _do_with_assert_raises():
-                for x in range(10):
-                    client_bufchan.emit('sleep', (x,))
-                    event = client_bufchan.recv(timeout=TIME_FACTOR * 3)
-                    assert event.name == 'OK'
-                    assert list(event.args) == [x]
-            pytest.raises(zerorpc.TimeoutExpired, _do_with_assert_raises)
-        else:
-            with pytest.raises(zerorpc.TimeoutExpired):
-                for x in range(10):
-                    client_bufchan.emit('sleep', (x,))
-                    event = client_bufchan.recv(timeout=TIME_FACTOR * 3)
-                    assert event.name == 'OK'
-                    assert list(event.args) == [x]
+        with pytest.raises(zerorpc.TimeoutExpired):
+            for x in range(10):
+                client_bufchan.emit('sleep', (x,))
+                event = client_bufchan.recv(timeout=TIME_FACTOR * 3)
+                assert event.name == 'OK'
+                assert list(event.args) == [x]
         client_bufchan.close()
 
     coro_pool = gevent.pool.Pool()
@@ -362,21 +335,12 @@ def test_do_some_req_rep_client_timeout():
         server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
         server_bufchan = zerorpc.BufferedChannel(server_hbchan)
 
-        if sys.version_info < (2, 7):
-            def _do_with_assert_raises():
-                for x in range(20):
-                    event = server_bufchan.recv()
-                    assert event.name == 'sleep'
-                    gevent.sleep(TIME_FACTOR * event.args[0])
-                    server_bufchan.emit('OK', event.args)
-            pytest.raises(zerorpc.LostRemote, _do_with_assert_raises)
-        else:
-            with pytest.raises(zerorpc.LostRemote):
-                for x in range(20):
-                    event = server_bufchan.recv()
-                    assert event.name == 'sleep'
-                    gevent.sleep(TIME_FACTOR * event.args[0])
-                    server_bufchan.emit('OK', event.args)
+        with pytest.raises(zerorpc.LostRemote):
+            for x in range(20):
+                event = server_bufchan.recv()
+                assert event.name == 'sleep'
+                gevent.sleep(TIME_FACTOR * event.args[0])
+                server_bufchan.emit('OK', event.args)
         server_bufchan.close()
 
 
@@ -418,25 +382,13 @@ def test_congestion_control_server_pushing():
         server_channel = server.channel(event)
         server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
         server_bufchan = zerorpc.BufferedChannel(server_hbchan, inqueue_size=100)
-        if sys.version_info < (2, 7):
-            def _do_with_assert_raises():
-                for x in range(200):
-                    server_bufchan.emit('coucou', x, timeout=0)  # will fail when x == 1
-            pytest.raises(zerorpc.TimeoutExpired, _do_with_assert_raises)
-        else:
-            with pytest.raises(zerorpc.TimeoutExpired):
-                for x in range(200):
-                    server_bufchan.emit('coucou', x, timeout=0)  # will fail when x == 1
+        with pytest.raises(zerorpc.TimeoutExpired):
+            for x in range(200):
+                server_bufchan.emit('coucou', x, timeout=0)  # will fail when x == 1
         server_bufchan.emit('coucou', 1)  # block until receiver is ready
-        if sys.version_info < (2, 7):
-            def _do_with_assert_raises():
-                for x in range(2, 200):
-                    server_bufchan.emit('coucou', x, timeout=0)  # will fail when x == 100
-            pytest.raises(zerorpc.TimeoutExpired, _do_with_assert_raises)
-        else:
-            with pytest.raises(zerorpc.TimeoutExpired):
-                for x in range(2, 200):
-                    server_bufchan.emit('coucou', x, timeout=0)  # will fail when x == 100
+        with pytest.raises(zerorpc.TimeoutExpired):
+            for x in range(2, 200):
+                server_bufchan.emit('coucou', x, timeout=0)  # will fail when x == 100
         for x in range(read_cnt.value, 200):
             server_bufchan.emit('coucou', x) # block until receiver is ready
         server_bufchan.close()

--- a/tests/test_client_async.py
+++ b/tests/test_client_async.py
@@ -55,13 +55,8 @@ def test_client_server_client_timeout_with_async():
 
     async_result = client.add(1, 4, async_=True)
 
-    if sys.version_info < (2, 7):
-        def _do_with_assert_raises():
-            print(async_result.get())
-        pytest.raises(zerorpc.TimeoutExpired, _do_with_assert_raises)
-    else:
-        with pytest.raises(zerorpc.TimeoutExpired):
-            print(async_result.get())
+    with pytest.raises(zerorpc.TimeoutExpired):
+        print(async_result.get())
     client.close()
     srv.close()
 

--- a/tests/test_client_heartbeat.py
+++ b/tests/test_client_heartbeat.py
@@ -23,8 +23,6 @@
 # SOFTWARE.
 
 
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import next
 from builtins import range
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -58,11 +58,8 @@ def test_close_server_hbchan():
     gevent.sleep(TIME_FACTOR * 3)
     print('CLOSE SERVER SOCKET!!!')
     server_hbchan.close()
-    if sys.version_info < (2, 7):
-        pytest.raises(zerorpc.LostRemote, client_hbchan.recv)
-    else:
-        with pytest.raises(zerorpc.LostRemote):
-            client_hbchan.recv()
+    with pytest.raises(zerorpc.LostRemote):
+        client_hbchan.recv()
     print('CLIENT LOST SERVER :)')
     client_hbchan.close()
     server.close()
@@ -91,11 +88,8 @@ def test_close_client_hbchan():
     gevent.sleep(TIME_FACTOR * 3)
     print('CLOSE CLIENT SOCKET!!!')
     client_hbchan.close()
-    if sys.version_info < (2, 7):
-        pytest.raises(zerorpc.LostRemote, server_hbchan.recv)
-    else:
-        with pytest.raises(zerorpc.LostRemote):
-            server_hbchan.recv()
+    with pytest.raises(zerorpc.LostRemote):
+        server_hbchan.recv()
     print('SERVER LOST CLIENT :)')
     server_hbchan.close()
     server.close()
@@ -122,11 +116,8 @@ def test_heartbeat_can_open_channel_server_close():
     gevent.sleep(TIME_FACTOR * 3)
     print('CLOSE SERVER SOCKET!!!')
     server_hbchan.close()
-    if sys.version_info < (2, 7):
-        pytest.raises(zerorpc.LostRemote, client_hbchan.recv)
-    else:
-        with pytest.raises(zerorpc.LostRemote):
-            client_hbchan.recv()
+    with pytest.raises(zerorpc.LostRemote):
+        client_hbchan.recv()
     print('CLIENT LOST SERVER :)')
     client_hbchan.close()
     server.close()
@@ -154,11 +145,8 @@ def test_heartbeat_can_open_channel_client_close():
     print('CLOSE CLIENT SOCKET!!!')
     client_hbchan.close()
     client.close()
-    if sys.version_info < (2, 7):
-        pytest.raises(zerorpc.LostRemote, server_hbchan.recv)
-    else:
-        with pytest.raises(zerorpc.LostRemote):
-            server_hbchan.recv()
+    with pytest.raises(zerorpc.LostRemote):
+        server_hbchan.recv()
     print('SERVER LOST CLIENT :)')
     server_hbchan.close()
     server.close()
@@ -226,11 +214,8 @@ def test_do_some_req_rep_lost_server():
             assert event.name == 'OK'
             assert list(event.args) == [x + x * x]
         client_hbchan.emit('add', (x, x * x))
-        if sys.version_info < (2, 7):
-            pytest.raises(zerorpc.LostRemote, client_hbchan.recv)
-        else:
-            with pytest.raises(zerorpc.LostRemote):
-                client_hbchan.recv()
+        with pytest.raises(zerorpc.LostRemote):
+            client_hbchan.recv()
         client_hbchan.close()
 
     client_task = gevent.spawn(client_do)
@@ -286,11 +271,8 @@ def test_do_some_req_rep_lost_client():
             assert event.name == 'add'
             server_hbchan.emit('OK', (sum(event.args),))
 
-        if sys.version_info < (2, 7):
-            pytest.raises(zerorpc.LostRemote, server_hbchan.recv)
-        else:
-            with pytest.raises(zerorpc.LostRemote):
-                server_hbchan.recv()
+        with pytest.raises(zerorpc.LostRemote):
+            server_hbchan.recv()
         server_hbchan.close()
 
     server_task = gevent.spawn(server_do)
@@ -315,21 +297,12 @@ def test_do_some_req_rep_client_timeout():
         client_channel = client.channel()
         client_hbchan = zerorpc.HeartBeatOnChannel(client_channel, freq=TIME_FACTOR * 2)
 
-        if sys.version_info < (2, 7):
-            def _do_with_assert_raises():
-                for x in range(10):
-                    client_hbchan.emit('sleep', (x,))
-                    event = client_hbchan.recv(timeout=TIME_FACTOR * 3)
-                    assert event.name == 'OK'
-                    assert list(event.args) == [x]
-            pytest.raises(zerorpc.TimeoutExpired, _do_with_assert_raises)
-        else:
-            with pytest.raises(zerorpc.TimeoutExpired):
-                for x in range(10):
-                    client_hbchan.emit('sleep', (x,))
-                    event = client_hbchan.recv(timeout=TIME_FACTOR * 3)
-                    assert event.name == 'OK'
-                    assert list(event.args) == [x]
+        with pytest.raises(zerorpc.TimeoutExpired):
+            for x in range(10):
+                client_hbchan.emit('sleep', (x,))
+                event = client_hbchan.recv(timeout=TIME_FACTOR * 3)
+                assert event.name == 'OK'
+                assert list(event.args) == [x]
         client_hbchan.close()
 
     client_task = gevent.spawn(client_do)
@@ -339,21 +312,12 @@ def test_do_some_req_rep_client_timeout():
         server_channel = server.channel(event)
         server_hbchan = zerorpc.HeartBeatOnChannel(server_channel, freq=TIME_FACTOR * 2)
 
-        if sys.version_info < (2, 7):
-            def _do_with_assert_raises():
-                for x in range(20):
-                    event = server_hbchan.recv()
-                    assert event.name == 'sleep'
-                    gevent.sleep(TIME_FACTOR * event.args[0])
-                    server_hbchan.emit('OK', event.args)
-            pytest.raises(zerorpc.LostRemote, _do_with_assert_raises)
-        else:
-            with pytest.raises(zerorpc.LostRemote):
-                for x in range(20):
-                    event = server_hbchan.recv()
-                    assert event.name == 'sleep'
-                    gevent.sleep(TIME_FACTOR * event.args[0])
-                    server_hbchan.emit('OK', event.args)
+        with pytest.raises(zerorpc.LostRemote):
+            for x in range(20):
+                event = server_hbchan.recv()
+                assert event.name == 'sleep'
+                gevent.sleep(TIME_FACTOR * event.args[0])
+                server_hbchan.emit('OK', event.args)
         server_hbchan.close()
 
     server_task = gevent.spawn(server_do)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -23,8 +23,6 @@
 # SOFTWARE.
 
 
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import str
 from future.utils import tobytes
 
@@ -100,11 +98,8 @@ def test_resolve_endpoint_events():
             return 'world'
 
     srv = Srv(heartbeat=TIME_FACTOR * 1, context=c)
-    if sys.version_info < (2, 7):
-        pytest.raises(zmq.ZMQError, srv.bind, 'some_service')
-    else:
-        with pytest.raises(zmq.ZMQError):
-            srv.bind('some_service')
+    with pytest.raises(zmq.ZMQError):
+        srv.bind('some_service')
 
     cnt = c.register_middleware(Resolver())
     assert cnt == 1

--- a/tests/test_middleware_before_after_exec.py
+++ b/tests/test_middleware_before_after_exec.py
@@ -22,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from __future__ import absolute_import
 from builtins import range
 
 import gevent

--- a/tests/test_reqstream.py
+++ b/tests/test_reqstream.py
@@ -23,8 +23,6 @@
 # SOFTWARE.
 
 
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import range
 
 import gevent

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -23,8 +23,6 @@
 # SOFTWARE.
 
 
-from __future__ import print_function
-from __future__ import absolute_import
 from builtins import range
 
 import pytest
@@ -113,11 +111,8 @@ def test_client_server_client_timeout():
     client = zerorpc.Client(timeout=TIME_FACTOR * 2)
     client.connect(endpoint)
 
-    if sys.version_info < (2, 7):
-        pytest.raises(zerorpc.TimeoutExpired, client.add, 1, 4)
-    else:
-        with pytest.raises(zerorpc.TimeoutExpired):
-            print(client.add(1, 4))
+    with pytest.raises(zerorpc.TimeoutExpired):
+        print(client.add(1, 4))
     client.close()
     srv.close()
 
@@ -137,13 +132,8 @@ def test_client_server_exception():
     client = zerorpc.Client(timeout=TIME_FACTOR * 2)
     client.connect(endpoint)
 
-    if sys.version_info < (2, 7):
-        def _do_with_assert_raises():
-            print(client.raise_something(42))
-        pytest.raises(zerorpc.RemoteError, _do_with_assert_raises)
-    else:
-        with pytest.raises(zerorpc.RemoteError):
-            print(client.raise_something(42))
+    with pytest.raises(zerorpc.RemoteError):
+        print(client.raise_something(42))
     assert client.raise_something(list(range(5))) == 4
     client.close()
     srv.close()
@@ -164,13 +154,8 @@ def test_client_server_detailed_exception():
     client = zerorpc.Client(timeout=TIME_FACTOR * 2)
     client.connect(endpoint)
 
-    if sys.version_info < (2, 7):
-        def _do_with_assert_raises():
-            print(client.raise_error())
-        pytest.raises(zerorpc.RemoteError, _do_with_assert_raises)
-    else:
-        with pytest.raises(zerorpc.RemoteError):
-            print(client.raise_error())
+    with pytest.raises(zerorpc.RemoteError):
+        print(client.raise_error())
     try:
         client.raise_error()
     except zerorpc.RemoteError as e:

--- a/tests/test_zmq.py
+++ b/tests/test_zmq.py
@@ -23,8 +23,6 @@
 # SOFTWARE.
 
 
-from __future__ import print_function
-from __future__ import absolute_import
 import gevent
 
 from zerorpc import zmq

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py35
+envlist = py34,py35
 
 [testenv]
 deps =

--- a/zerorpc/events.py
+++ b/zerorpc/events.py
@@ -42,13 +42,6 @@ from .context import Context
 from .channel_base import ChannelBase
 
 
-if sys.version_info < (2, 7):
-    def get_pyzmq_frame_buffer(frame):
-        return frame.buffer[:]
-else:
-    def get_pyzmq_frame_buffer(frame):
-        return frame.buffer
-
 # gevent <= 1.1.0.rc5 is missing the Python3 __next__ method.
 if sys.version_info >= (3, 0) and gevent.version_info <= (1, 1, 0, 'rc', '5'):
     setattr(gevent.queue.Channel, '__next__', gevent.queue.Channel.next)
@@ -362,7 +355,7 @@ class Events(ChannelBase):
         else:
             identity = None
             blob = parts[0]
-        event = Event.unpack(get_pyzmq_frame_buffer(blob))
+        event = Event.unpack(blob.buffer)
         event.identity = identity
         if self._debug:
             logger.debug('<-- %s', event)


### PR DESCRIPTION
Python 2 was sunset on January 1st 2020, i.e. two years ago; it is
about time to move on and focus our efforts on Python 3.

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>