### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -207,7 +207,7 @@ exception is raised), we use the ERR event.
 	- Name of the error (it should be the exception class name, or another
 	  meaningful keyword).
 	- Human representation of the error (preferably in english).
-	- If possible a pretty printed traceback of the call stack when the error occured.
+	- If possible a pretty printed traceback of the call stack when the error occurred.
 
 > A future version of the protocol will probably add a structured version of the
 > traceback, allowing machine-to-machine stack walking and better cross-language

--- a/zerorpc/core.py
+++ b/zerorpc/core.py
@@ -406,7 +406,7 @@ def fork_task_context(functor, context=None):
               - task1 is created to handle this event this task will be linked
                 to the initial event context. zerorpc.Server does that for you.
               - task1 make use of some zerorpc.Client instances, the initial
-                event context is transfered on every call.
+                event context is transferred on every call.
 
               - task1 spawn a new task2.
               - task2 make use of some zerorpc.Client instances, it's a fresh
@@ -415,7 +415,7 @@ def fork_task_context(functor, context=None):
 
               - task1 spawn a new fork_task_context(task3).
               - task3 make use of some zerorpc.Client instances, the initial
-                event context is transfered on every call.
+                event context is transferred on every call.
 
         A real use case is a distributed tracer. Each time a new event is
         created, a trace_id is injected in it or copied from the current task


### PR DESCRIPTION
There are small typos in:
- doc/protocol.md
- zerorpc/core.py

Fixes:
- Should read `transferred` rather than `transfered`.
- Should read `occurred` rather than `occured`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md